### PR TITLE
Package linksem.0.3

### DIFF
--- a/packages/linksem/linksem.0.3/descr
+++ b/packages/linksem/linksem.0.3/descr
@@ -1,0 +1,1 @@
+A formalisation of the core ELF file format, the de facto standard executable and linkable file format on Linux and related systems, written in Lem.  This formalisation has been tested against approximately 5,000 ELF binaries found "in the wild" on various different platforms.

--- a/packages/linksem/linksem.0.3/opam
+++ b/packages/linksem/linksem.0.3/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "Stephen Kell <Stephen.Kell@cl.cam.ac.uk>"
+authors: ["Stephen Kell" "Dominic Mulligan" "Peter Sewell"]
+homepage: "https://github.com/rems-project/linksem"
+bug-reports: "https://github.com/rems-project/linksem/issues"
+license: "?"
+dev-repo: "http://github.com/rems-project/linksem.git"
+build: [make]
+install: [make "install"]
+remove: [make "uninstall"]
+depends: [
+  "ocamlfind"
+  "ocamlbuild"
+  "lem" {>= "2018-05-11"}
+]

--- a/packages/linksem/linksem.0.3/url
+++ b/packages/linksem/linksem.0.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/rems-project/linksem/archive/0.3.tar.gz"
+checksum: "1c4e2937b0ddfaddfc216d610fdb0a03"


### PR DESCRIPTION
### `linksem.0.3`

A formalisation of the core ELF file format, the de facto standard executable and linkable file format on Linux and related systems, written in Lem.  This formalisation has been tested against approximately 5,000 ELF binaries found "in the wild" on various different platforms.



---
* Homepage: https://github.com/rems-project/linksem
* Source repo: http://github.com/rems-project/linksem.git
* Bug tracker: https://github.com/rems-project/linksem/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

:camel: Pull-request generated by opam-publish v0.3.5