### PR TITLE
Package sail.0.3

### DIFF
--- a/packages/sail/sail.0.3/descr
+++ b/packages/sail/sail.0.3/descr
@@ -1,0 +1,2 @@
+Sail is a language for describing the instruction semantics of processors.
+It has been used in several papers, available from http://www.cl.cam.ac.uk/~pes20/sail/.

--- a/packages/sail/sail.0.3/opam
+++ b/packages/sail/sail.0.3/opam
@@ -1,0 +1,34 @@
+opam-version: "1.2"
+maintainer: "Sail Devs <cl-sail-dev@lists.cam.ac.uk>"
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+homepage: "http://www.cl.cam.ac.uk/~pes20/sail/"
+bug-reports: "https://github.com/rems-project/sail/issues"
+license: "BSD3"
+dev-repo: "https://github.com/rems-project/sail.git"
+build: [make "INSTALL_DIR=%{prefix}%" "SHARE_DIR=%{sail:share}%" "isail"]
+install: [make "INSTALL_DIR=%{prefix}%" "SHARE_DIR=%{sail:share}%" "install"]
+remove: [
+  make "INSTALL_DIR=%{prefix}%" "SHARE_DIR=%{sail:share}%" "uninstall"
+]
+depends: [
+  "ocamlfind"
+  "ocamlbuild"
+  "zarith"
+  "menhir"
+  "linenoise"
+  "ott" {>= "0.28"}
+  "lem"
+  "linksem" {>= "0.3"}
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/sail/sail.0.3/url
+++ b/packages/sail/sail.0.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/rems-project/sail/archive/0.3.tar.gz"
+checksum: "486f320ad72eb8a8ee4cd1184fd43057"


### PR DESCRIPTION
### `sail.0.3`

Sail is a language for describing the instruction semantics of processors.
It has been used in several papers, available from http://www.cl.cam.ac.uk/~pes20/sail/.


---
* Homepage: http://www.cl.cam.ac.uk/~pes20/sail/
* Source repo: https://github.com/rems-project/sail.git
* Bug tracker: https://github.com/rems-project/sail/issues

---
### opam-lint failures
- **WARNING** 41 Some packages are mentionned in package scripts of features, but there is no dependency or depopt toward them: "sail"

---

:camel: Pull-request generated by opam-publish v0.3.5