### PR TITLE
Package sail-riscv.0.5

### DIFF
--- a/packages/sail-riscv/sail-riscv.0.5/opam
+++ b/packages/sail-riscv/sail-riscv.0.5/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Sail Devs <cl-sail-dev@lists.cam.ac.uk>"
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Prashanth Mundkur"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+]
+homepage: "https://github.com/rems-project/sail-riscv/"
+bug-reports: "https://github.com/rems-project/sail-riscv/issues"
+license: "BSD3"
+dev-repo: "git+https://github.com/rems-project/sail-riscv.git"
+build: [make "LEM_DIR=%{lem:share}%" "SAIL_DIR=%{sail:share}%" "SAIL=sail" "opam-build"]
+depends: [
+  "ocaml" {>= "4.06.1"}
+  "ocamlfind"
+  "ocamlbuild"
+  "lem"
+  "sail" {>= "0.9"}
+  "linksem" {>= "0.3"}
+  "conf-gmp"
+  "conf-zlib"
+]
+synopsis:
+  "This package installs a RISC-V emulator (32 and 64 bits) built form the Sail model at https://github.com/rems-project/sail-riscv"
+url {
+  src: "https://github.com/rems-project/sail-riscv/archive/0.5.tar.gz"
+  checksum: [
+    "md5=74ca225849c97bcaebf7983cfc5b914f"
+    "sha512=5e84d0876f2853280853f8fc8877850af58017fd65421b67cede14bab139b6008b40d8a7c100338d4301da3b89e907768ee096ae53b4e4356fa14a71f55b48e7"
+  ]
+}


### PR DESCRIPTION
### `sail-riscv.0.5`
This package installs a RISC-V emulator (32 and 64 bits) built form the Sail model at https://github.com/rems-project/sail-riscv



---
* Homepage: https://github.com/rems-project/sail-riscv/
* Source repo: git+https://github.com/rems-project/sail-riscv.git
* Bug tracker: https://github.com/rems-project/sail-riscv/issues

---
:camel: Pull-request generated by opam-publish v2.0.2