### PR TITLE
Package sail-legacy.0.1

### DIFF
--- a/packages/sail-legacy/sail-legacy.0.1/opam
+++ b/packages/sail-legacy/sail-legacy.0.1/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: "Sail Devs <cl-sail-dev@lists.cam.ac.uk>"
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+homepage: "http://www.cl.cam.ac.uk/~pes20/sail/"
+bug-reports: "https://github.com/rems-project/sail/issues"
+license: "BSD3"
+dev-repo: "git+https://github.com/rems-project/sail.git#legacy"
+build: [make "INSTALL_DIR=%{prefix}%" "SHARE_DIR=%{sail-legacy:share}%" "sail"]
+install: [make "INSTALL_DIR=%{prefix}%" "SHARE_DIR=%{sail-legacy:share}%" "install"]
+depends: [
+  "ocaml" {>= "4.06.1"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "zarith"
+  "ott" {>= "0.28" & build}
+  "lem" {>= "2018-12-14"}
+  "linksem" {>= "0.3"}
+  "conf-gmp"
+  "conf-zlib"
+  "pprint"
+  "num"
+]
+synopsis:
+  "This is a legacy version of the Sail language, and should not be used"
+description:
+  """Sail is a language for describing the instruction-set
+architecture (ISA) semantics of processors. This is a legacy version
+to support RMEM and should not be used. Use the "sail" package instead."""
+url {
+  src: "https://github.com/rems-project/sail/archive/legacy-0.1.tar.gz"
+  checksum: [
+    "md5=c48e50636ce724d3a8d30f6b756415c2"
+    "sha512=559384b11cc3761ae7e4023af03f94ff4c6e2d325a644e16742d55415b59e4fd1f9089928355b0644c791bfdcf90b8987d7dbf6d88f3fd0ff2ee285363a908f1"
+  ]
+}


### PR DESCRIPTION
### `sail-legacy.0.1`
This is a legacy version of the Sail language, and should not be used
Sail is a language for describing the instruction-set
architecture (ISA) semantics of processors. This is a legacy version
to support RMEM and should not be used. Use the "sail" package instead.



---
* Homepage: http://www.cl.cam.ac.uk/~pes20/sail/
* Source repo: git+https://github.com/rems-project/sail.git#legacy
* Bug tracker: https://github.com/rems-project/sail/issues

---
:camel: Pull-request generated by opam-publish v2.0.2