### PR TITLE
Package sail-legacy.0.1

### DIFF
--- a/packages/sail-legacy/sail-legacy.0.1/opam
+++ b/packages/sail-legacy/sail-legacy.0.1/opam
@@ -32,15 +32,15 @@ depends: [
   "num"
 ]
 synopsis:
-  "This is a legacy version of the Sail language, and should not be used"
+  "This is a legacy version of the Sail language to support RMEM, and should not be used elsewhere"
 description:
   """Sail is a language for describing the instruction-set
 architecture (ISA) semantics of processors. This is a legacy version
-to support RMEM and should not be used. Use the "sail" package instead."""
+to support RMEM and should not be used elsewhere. Use the "sail" package instead."""
 url {
-  src: "https://github.com/rems-project/sail/archive/legacy-0.11.tar.gz"
+  src: "https://github.com/rems-project/sail/archive/legacy-0.1.tar.gz"
   checksum: [
-    "md5=d796ca96b1b2da55c386a0d60af82418"
-    "sha512=064c1de420c78b6b65a3b7b61119bb0f591493d32f7289a84ed5dbdace43691c3b25621860efff9d31c79240d334c1494faf45d3a75afba55011f9d5665df28a"
+    "md5=c48e50636ce724d3a8d30f6b756415c2"
+    "sha512=559384b11cc3761ae7e4023af03f94ff4c6e2d325a644e16742d55415b59e4fd1f9089928355b0644c791bfdcf90b8987d7dbf6d88f3fd0ff2ee285363a908f1"
   ]
 }


### PR DESCRIPTION
### `sail-legacy.0.1`
This is a legacy version of the Sail language to support RMEM, and should not be used elsewhere
Sail is a language for describing the instruction-set
architecture (ISA) semantics of processors. This is a legacy version
to support RMEM and should not be used elsewhere. Use the "sail" package instead.



---
* Homepage: http://www.cl.cam.ac.uk/~pes20/sail/
* Source repo: git+https://github.com/rems-project/sail.git#legacy
* Bug tracker: https://github.com/rems-project/sail/issues

---
:camel: Pull-request generated by opam-publish v2.0.2