### PR TITLE
Package rmem.0.1

### DIFF
--- a/packages/rmem/rmem.0.1/opam
+++ b/packages/rmem/rmem.0.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Executable concurrency models for ARMv8, RISC-V, Power, and x86"
+description: """
+The rmem tool comprises executable operational models for the relaxed-memory concurrency semantics of the Power, ARMv8, RISC-V, and x86 (TSO) processor architectures, as well as machinery for executing the models on litmus tests and ELF binaries: allowing one to interactively step through the legal concurrency behaviours, pseudorandomly find legal outcomes, and exhaustively enumerate all architecturally allowed outcomes of small bounded concurrent programs. For ARM, it supports both the current ARMv8-A multicopy atomic model and the earlier ARMv8-A non-multicopy-atomic model.
+"""
+maintainer: "rmem devs <cl-rmem-dev@lists.cam.ac.uk>"
+authors: "the rmem developers (see homepage)"
+license: "2-Clause BSD"
+homepage: "https://github.com/rems-project/rmem"
+bug-reports: "https://github.com/rems-project/rmem/issues"
+dev-repo: "git+https://github.com/rems-project/rmem.git"
+depends: [ 
+  "ocaml" {>= "4.06.1"}
+  "ocamlfind"
+  "ocamlbuild"
+  "lem" {>= "2018-12-14"}
+  "linksem" {>= "0.3"}
+  "sail"
+  "sail-riscv"
+  "conf-gmp"
+  "lwt" {>= "4.1.0" & <= "4.5.0"}
+  "lambda-term" {>= "1.13"}
+  "zarith"
+#  "js_of_ocaml" {<= "3.3.0"}
+#  "js_of_ocaml-ppx" {<= "3.3.0"}
+  "base64"
+  "zed" {>= "1.6"}
+]
+build: [make "SHARE_DIR=%{rmem:share}%"]
+install: [make "INSTALL_DIR=%{prefix}%" "SHARE_DIR=%{rmem:share}%" "install"]
+url {
+  src: "https://github.com/rems-project/rmem/archive/0.1.tar.gz"
+  checksum: [
+    "md5=2ee2ad588f486519917625c398f07de2"
+    "sha512=f86461991c607c16b43e4780c229d47907e5c837d4e9d194f1106afcba06631c30c7fa01d33df3d040ac9f68e06a2415cbf87f50aabde0fffe440cbcf2eba30c"
+  ]
+}


### PR DESCRIPTION
### `rmem.0.1`
Executable concurrency models for ARMv8, RISC-V, Power, and x86
The rmem tool comprises executable operational models for the relaxed-memory concurrency semantics of the Power, ARMv8, RISC-V, and x86 (TSO) processor architectures, as well as machinery for executing the models on litmus tests and ELF binaries: allowing one to interactively step through the legal concurrency behaviours, pseudorandomly find legal outcomes, and exhaustively enumerate all architecturally allowed outcomes of small bounded concurrent programs. For ARM, it supports both the current ARMv8-A multicopy atomic model and the earlier ARMv8-A non-multicopy-atomic model.



---
* Homepage: https://github.com/rems-project/rmem
* Source repo: git+https://github.com/rems-project/rmem.git
* Bug tracker: https://github.com/rems-project/rmem/issues

---
:camel: Pull-request generated by opam-publish v2.0.2