### PR TITLE
Constrain old sail versions to omd<1.4

### DIFF
--- a/packages/sail/sail.0.10/opam
+++ b/packages/sail/sail.0.10/opam
@@ -31,7 +31,7 @@ depends: [
   "ott" {>= "0.28"}
   "lem" {>= "2018-12-14"}
   "linksem" {>= "0.3"}
-  "omd"
+  "omd" {< "1.4"}
   "conf-gmp"
   "conf-zlib"
   "base64" {< "3.0.0"}

--- a/packages/sail/sail.0.11/opam
+++ b/packages/sail/sail.0.11/opam
@@ -31,7 +31,7 @@ depends: [
   "ott" {>= "0.28"}
   "lem" {>= "2018-12-14"}
   "linksem" {>= "0.3"}
-  "omd"
+  "omd" {< "1.4"}
   "conf-gmp"
   "conf-zlib"
   "base64" {< "3.0.0"}

--- a/packages/sail/sail.0.12/opam
+++ b/packages/sail/sail.0.12/opam
@@ -31,7 +31,7 @@ depends: [
   "ott" {>= "0.28"}
   "lem" {>= "2018-12-14"}
   "linksem" {>= "0.3"}
-  "omd"
+  "omd" {< "1.4"}
   "conf-gmp"
   "conf-zlib"
   "base64" {< "3.0.0"}

--- a/packages/sail/sail.0.13/opam
+++ b/packages/sail/sail.0.13/opam
@@ -31,7 +31,7 @@ depends: [
   "ott" {>= "0.28" & build}
   "lem" {>= "2018-12-14"}
   "linksem" {>= "0.3"}
-  "omd" {>= "1.3.1"}
+  "omd" {>= "1.3.1" & < "1.4"}
   "conf-gmp"
   "conf-zlib"
   "base64" {>= "3.1.0"}

--- a/packages/sail/sail.0.5/opam
+++ b/packages/sail/sail.0.5/opam
@@ -31,7 +31,7 @@ depends: [
   "ott" {>= "0.28"}
   "lem"
   "linksem" {>= "0.3"}
-  "omd"
+  "omd" {< "1.4"}
   "conf-gmp"
   "conf-zlib"
 ]

--- a/packages/sail/sail.0.6/opam
+++ b/packages/sail/sail.0.6/opam
@@ -31,7 +31,7 @@ depends: [
   "ott" {>= "0.28"}
   "lem" {>= "2018-12-14"}
   "linksem" {>= "0.3"}
-  "omd"
+  "omd" {< "1.4"}
   "conf-gmp"
   "conf-zlib"
 ]

--- a/packages/sail/sail.0.7.1/opam
+++ b/packages/sail/sail.0.7.1/opam
@@ -31,7 +31,7 @@ depends: [
   "ott" {>= "0.28"}
   "lem" {>= "2018-12-14"}
   "linksem" {>= "0.3"}
-  "omd"
+  "omd" {< "1.4"}
   "conf-gmp"
   "conf-zlib"
 ]

--- a/packages/sail/sail.0.7/opam
+++ b/packages/sail/sail.0.7/opam
@@ -31,7 +31,7 @@ depends: [
   "ott" {>= "0.28"}
   "lem" {>= "2018-12-14"}
   "linksem" {>= "0.3"}
-  "omd"
+  "omd" {< "1.4"}
   "conf-gmp"
   "conf-zlib"
 ]

--- a/packages/sail/sail.0.8/opam
+++ b/packages/sail/sail.0.8/opam
@@ -31,7 +31,7 @@ depends: [
   "ott" {>= "0.28"}
   "lem" {>= "2018-12-14"}
   "linksem" {>= "0.3"}
-  "omd"
+  "omd" {< "1.4"}
   "conf-gmp"
   "conf-zlib"
   "yojson"

--- a/packages/sail/sail.0.9/opam
+++ b/packages/sail/sail.0.9/opam
@@ -31,7 +31,7 @@ depends: [
   "ott" {>= "0.28"}
   "lem" {>= "2018-12-14"}
   "linksem" {>= "0.3"}
-  "omd"
+  "omd" {< "1.4"}
   "conf-gmp"
   "conf-zlib"
   "base64" {< "3.0.0"}


### PR DESCRIPTION
As you probably know, leaving it unconstrained can result in opam trying
to build sail with omd 2.0.0~alpha2, which ends up producing an error something
like:

```
File "latex.ml", line 226, characters 6-21:
226 |     | Paragraph elems ->
            ^^^^^^^^^^^^^^^
Error: The constructor Paragraph expects 2 argument(s),
       but is applied here to 1 argument(s)
```

... due to omd 2's revamp of the
AST (<https://github.com/ocaml/omd/pull/234>).

Anyway, it turns out that opam can still end up picking sail 0.13 and
earlier, which (unlike version 0.14) don't yet have this constraint, and
so still fail fail to build in this manner.

I'm not really sure why sail 0.14 chose the constraint "omd<1.4", but in
the interest of monotonicity, I elected to apply the same one retroactively:

``` sh
opam admin add-constraint 'omd<1.4'
```

It may seem alarming to update existing packages in this way, but
apparently this is the state-of-the-art in opam repository
administration at the moment. (Meaning: nobody's managed to figure out
how to avoid needing to do it.)

Apparently, nothing too terrible happens as long as you restrict such
changes to tightening up version constraints, and don't do so in ways
that would prevent something that worked before from working now. Since
this change only excludes two versions of omd that currently
exist (2.0.0~alpha1 and 2.0.0~alpha2), which as we've seen don't work
for sail, we should be fine.